### PR TITLE
a standarized way to bootstrap component

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,8 +5,9 @@ import { Provider } from 'react-redux';
 import reducers from './reducers/reducers';
 import Foobar from './components/foobar';
 import thunkMiddleware from 'redux-thunk';
+import { name } from '../package.json';
 
-const container = document.getElementById('tfs4jira__foobar');
+const container = document.getElementById(name);
 const data = JSON.parse(container.getAttribute('data-initial'));
 
 const store = createStore(

--- a/src/runner.html
+++ b/src/runner.html
@@ -6,7 +6,7 @@
 </head>
 <body>
 
-    <div id='tfs4jira__foobar' data-initial='{"foo":"spartez"}'></div>
+    <div id='@spartez/tfs4jira-module' data-initial='{"foo":"spartez"}'></div>
     <script src='/dist/index.js'></script>
 
 </body>


### PR DESCRIPTION
I changed the way how we integrate components and thought we may use module's name as component's container id. 

W3C documentation states that there are no restrictions on what form an ID can take. Nevertheless I'm curious how browsers (IE?) will handle this.

https://www.w3.org/TR/html5/dom.html#the-id-attribute